### PR TITLE
【PC画面】サイドバーの要素よりページのメイン要素（中心コンテンツ）が上に重なるように調整

### DIFF
--- a/src/app/layout.module.scss
+++ b/src/app/layout.module.scss
@@ -27,6 +27,7 @@ $layout-gap: 20px;
 
 .layout-page {
   @include pc {
+    position: relative;
     width: $page-width;
     border-right: 1px solid #e4e2e4;
     border-left: 1px solid #e4e2e4;


### PR DESCRIPTION
サイドバーの要素の表示がメイン要素より上に重なってしまうせいで、
検索フォーム等の入力ができなくなってしまっていたため修正🙇‍♂️🙏

■下記スレッドを参照
https://qinsalon.slack.com/archives/C0596469BM1/p1686353310632469
https://qinsalon.slack.com/archives/C0596469BM1/p1686375023220779?thread_ts=1686363816.901959&cid=C0596469BM1