### PR TITLE
#39 レシピカードの調整をしました

### DIFF
--- a/src/app/(top)/page.tsx
+++ b/src/app/(top)/page.tsx
@@ -98,6 +98,7 @@ export default function Page() {
                 favCountNumber={recipe.favCountNumber}
                 name={recipe.name}
                 description={recipe.description}
+                isTop
               />
             </Link>
           ))}

--- a/src/components/RecipeCard/RecipeCard.module.scss
+++ b/src/components/RecipeCard/RecipeCard.module.scss
@@ -1,9 +1,17 @@
 @import "@/styles/mixin";
 
+.imgWrapperTop {
+  position: relative;
+  width: 160px;
+  height: 160px;
+  margin-bottom: 5px;
+}
+
 .imgWrapper {
   position: relative;
   width: 173px;
   height: 173px;
+  margin-bottom: 5px;
 }
 
 .img {
@@ -48,7 +56,6 @@
   font-weight: 700;
   font-size: 12px;
   line-height: 18px;
-  width: 173px;
   word-wrap: break-word;
   overflow: hidden;
   text-overflow: ellipsis;
@@ -68,7 +75,6 @@
   order: 1;
   align-self: stretch;
   flex-grow: 0;
-  width: 173px;
   word-wrap: break-word;
   overflow: hidden;
   text-overflow: ellipsis;

--- a/src/components/RecipeCard/RecipeCard.tsx
+++ b/src/components/RecipeCard/RecipeCard.tsx
@@ -27,7 +27,7 @@ export const RecipeCard: React.FC<RecipeCardProps> = ({
           src="/images/recipe-dummy.png"
           alt=""
           width={173}
-          height={174}
+          height={173}
           className={styles.img}
         />
       </div>

--- a/src/components/RecipeCard/RecipeCard.tsx
+++ b/src/components/RecipeCard/RecipeCard.tsx
@@ -16,12 +16,14 @@ export const RecipeCard: React.FC<RecipeCardProps> = ({
   return (
     <div>
       <div className={styles.imgWrapper}>
-        <div className={styles.favCount}>
-          <Image src="/icon/heart.svg" width={10} height={9} alt="" />
-          <span className={styles.favNumber}>
-            {favCountNumber.toLocaleString()}
-          </span>
-        </div>
+        {favCountNumber > 0 && (
+          <div className={styles.favCount}>
+            <Image src="/icon/heart.svg" width={10} height={9} alt="" />
+            <span className={styles.favNumber}>
+              {favCountNumber.toLocaleString()}
+            </span>
+          </div>
+        )}
 
         <Image
           src="/images/recipe-dummy.png"

--- a/src/components/RecipeCard/RecipeCard.tsx
+++ b/src/components/RecipeCard/RecipeCard.tsx
@@ -6,16 +6,18 @@ export interface RecipeCardProps {
   favCountNumber: number;
   name: string;
   description: string;
+  isTop?: boolean;
 }
 
 export const RecipeCard: React.FC<RecipeCardProps> = ({
   favCountNumber,
   name,
   description,
+  isTop = false,
 }) => {
   return (
     <div>
-      <div className={styles.imgWrapper}>
+      <div className={isTop ? styles.imgWrapperTop : styles.imgWrapper}>
         {favCountNumber > 0 && (
           <div className={styles.favCount}>
             <Image src="/icon/heart.svg" width={10} height={9} alt="" />
@@ -28,8 +30,8 @@ export const RecipeCard: React.FC<RecipeCardProps> = ({
         <Image
           src="/images/recipe-dummy.png"
           alt=""
-          width={173}
-          height={173}
+          width={isTop ? 160 : 173}
+          height={isTop ? 160 : 173}
           className={styles.img}
         />
       </div>


### PR DESCRIPTION
## このプルリクエストで何をしたのか

- いいね数が0だった場合は右上に何も表示しないようにしました
- レシピカードの大きさをTop画面か否かで分けるようにしました
  - top画面は160x160, それ以外（検索結果も含む）は173x173
<img width="1002" alt="image" src="https://github.com/qin-team-recipe/01-frontend/assets/61014298/48c31001-32c6-46c6-986d-7057d96b5f6f">

## 対象issue
<!-- 例) close #12 -->
close #39 

## 重点的に見てほしいところ(不安なところ)

## 後回しにしたところ

## 参考情報
- いいねカウントは0の時以外に出るようになりました
<img width="573" alt="スクリーンショット 2023-07-27 23 04 44" src="https://github.com/qin-team-recipe/01-frontend/assets/61014298/8b473352-3614-41c9-ab94-0665eed99ee6">

## 備考
- 一旦最大でも173x173にしてみたものの、これで足りるのかどうかはまた後ほど調整でも良いでしょうか？
  - というのも、スカスカ具合がわからず、、