### PR TITLE
レシピカードの追加対応2

### DIFF
--- a/src/components/RecipeCard/RecipeCard.module.scss
+++ b/src/components/RecipeCard/RecipeCard.module.scss
@@ -9,8 +9,8 @@
 
 .imgWrapper {
   position: relative;
-  width: 173px;
-  height: 173px;
+  width: 214px;
+  height: 214px;
   margin-bottom: 5px;
 }
 

--- a/src/components/RecipeCard/RecipeCard.module.scss
+++ b/src/components/RecipeCard/RecipeCard.module.scss
@@ -87,3 +87,8 @@
   width: 14px;
   height: 14px;
 }
+
+.not-public {
+  font-size: 12px;
+  color: #ffffff;
+}

--- a/src/components/RecipeCard/RecipeCard.module.scss
+++ b/src/components/RecipeCard/RecipeCard.module.scss
@@ -82,3 +82,8 @@
   -webkit-box-orient: vertical;
   -webkit-line-clamp: 1;
 }
+
+.icon-heart {
+  width: 14px;
+  height: 14px;
+}

--- a/src/components/RecipeCard/RecipeCard.tsx
+++ b/src/components/RecipeCard/RecipeCard.tsx
@@ -30,9 +30,8 @@ export const RecipeCard: React.FC<RecipeCardProps> = ({
         <Image
           src="/images/recipe-dummy.png"
           alt=""
-          width={isTop ? 160 : 173}
-          height={isTop ? 160 : 173}
           className={styles.img}
+          fill
         />
       </div>
 

--- a/src/components/RecipeCard/RecipeCard.tsx
+++ b/src/components/RecipeCard/RecipeCard.tsx
@@ -7,6 +7,7 @@ export type RecipeCardProps = {
   name: string;
   description: string;
   favoriteCount: number;
+  thumbnail: string;
   isPublic?: boolean;
   isTop?: boolean;
 };
@@ -15,6 +16,7 @@ export const RecipeCard: React.FC<RecipeCardProps> = ({
   favoriteCount,
   name,
   description,
+  thumbnail,
   isPublic = true,
   isTop = false,
 }) => {
@@ -38,12 +40,7 @@ export const RecipeCard: React.FC<RecipeCardProps> = ({
           </span>
         )}
 
-        <Image
-          src="/images/recipe-dummy.png"
-          alt=""
-          className={styles.img}
-          fill
-        />
+        <Image src={thumbnail} alt="" className={styles.img} fill />
       </div>
 
       <h1 className={styles["recipe-name"]}>{name}</h1>

--- a/src/components/RecipeCard/RecipeCard.tsx
+++ b/src/components/RecipeCard/RecipeCard.tsx
@@ -1,5 +1,6 @@
 import Image from "next/image";
 
+import { IconHeart } from "../Icon";
 import styles from "./RecipeCard.module.scss";
 
 export interface RecipeCardProps {
@@ -20,7 +21,9 @@ export const RecipeCard: React.FC<RecipeCardProps> = ({
       <div className={isTop ? styles.imgWrapperTop : styles.imgWrapper}>
         {favCountNumber > 0 && (
           <div className={styles.favCount}>
-            <Image src="/icon/heart.svg" width={10} height={9} alt="" />
+            <span className={styles["icon-heart"]}>
+              <IconHeart color="#FFFFFF" />
+            </span>
             <span className={styles.favNumber}>
               {favCountNumber.toLocaleString()}
             </span>

--- a/src/components/RecipeCard/RecipeCard.tsx
+++ b/src/components/RecipeCard/RecipeCard.tsx
@@ -3,31 +3,39 @@ import Image from "next/image";
 import { IconHeart } from "../Icon";
 import styles from "./RecipeCard.module.scss";
 
-export interface RecipeCardProps {
-  favCountNumber: number;
+export type RecipeCardProps = {
   name: string;
   description: string;
+  favoriteCount: number;
+  isPublic?: boolean;
   isTop?: boolean;
-}
+};
 
 export const RecipeCard: React.FC<RecipeCardProps> = ({
-  favCountNumber,
+  favoriteCount,
   name,
   description,
+  isPublic = true,
   isTop = false,
 }) => {
   return (
     <div>
       <div className={isTop ? styles.imgWrapperTop : styles.imgWrapper}>
-        {favCountNumber > 0 && (
-          <div className={styles.favCount}>
-            <span className={styles["icon-heart"]}>
-              <IconHeart color="#FFFFFF" />
-            </span>
-            <span className={styles.favNumber}>
-              {favCountNumber.toLocaleString()}
-            </span>
-          </div>
+        {isPublic ? (
+          favoriteCount > 0 && (
+            <div className={styles.favCount}>
+              <span className={styles["icon-heart"]}>
+                <IconHeart color="#FFFFFF" />
+              </span>
+              <span className={styles.favNumber}>
+                {favoriteCount.toLocaleString()}
+              </span>
+            </div>
+          )
+        ) : (
+          <span className={`${styles.favCount} ${styles["not-public"]}`}>
+            非公開
+          </span>
         )}
 
         <Image


### PR DESCRIPTION
## このプルリクエストで何をしたのか
- お気に入り一覧を作成するにあたって、レシピカードを修正しました。

## 対象issue
close #66

## 重点的に見てほしいところ(不安なところ)
- 画像の大きさにwidthとheightで設定されているのを削除して、fill属性を追加しました。
  - それによって画像の外側のwidthとheightを設定することによって検索結果一覧の画像も大きくできました。
- propsの「favCountNumber」をテーブル項目の「favoriteCount」と合わせました。（合ってますよね？）

## 後回しにしたところ

## 参考情報

## 備考
